### PR TITLE
Explicitly telling Python msigdb file is in UTF8 encoding (fixes Windows issue)

### DIFF
--- a/genefeast/gf.py
+++ b/genefeast/gf.py
@@ -142,7 +142,7 @@ def gf(mif_path, output_dir, cfg_yaml_path):
         
     print(MSIGDB_HTML)
         
-    msigdb_file = open(MSIGDB_HTML, "r")
+    msigdb_file = open(MSIGDB_HTML, "r", encoding='UTF8')
     msigdb_contents = msigdb_file.read()
     msigdb_html_soup = BeautifulSoup(msigdb_contents, features="lxml")
     


### PR DESCRIPTION
encoding='UTF8' is explicitly specified when opening msigdb html file. 

This addresses an error that occurs when trying to read in the Polish character Ł. One can surmise there are more such characters from various alphabets, but the above solution addresses them all.