### PR TITLE
GeneFeast updated to work with Python 3.12 (with dependencies management using Poetry)

### DIFF
--- a/genefeast/gf.py
+++ b/genefeast/gf.py
@@ -34,8 +34,8 @@ def main():
 def gf(mif_path, output_dir, cfg_yaml_path):
     # MAIN PROGRAM ****************************************************************
     # 0. CHECK PYTHON VERSION *****************************************************
-    if(not(sys.version_info.major==3 and sys.version_info.minor==7)):
-        print('GeneFEAST requires Python 3.7. Please make sure you have a compliant version installed.')
+    if(not(sys.version_info.major==3 and sys.version_info.minor==12)):
+        print('GeneFEAST requires Python 3.12. Please make sure you have a compliant version installed.')
         sys.exit()
     
     # 1. SET UP I/O FILES AND DIRECTORIES *****************************************
@@ -142,7 +142,7 @@ def gf(mif_path, output_dir, cfg_yaml_path):
         
     print(MSIGDB_HTML)
         
-    msigdb_file = open(MSIGDB_HTML, "r")
+    msigdb_file = open(MSIGDB_HTML, "r", encoding='UTF8')
     msigdb_contents = msigdb_file.read()
     msigdb_html_soup = BeautifulSoup(msigdb_contents, features="lxml")
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,44 +1,41 @@
 [build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
-[project]
+[tool.poetry]
 name = "genefeast"
-version = "0.0.22"
-authors = [
-  { name="Avigail Taylor", email="avigail.taylor@well.ox.ac.uk" },
-]
+version = "0.0.23"
+authors = ["Avigail Taylor <avigail.taylor@well.ox.ac.uk>"]
 description = "Gene-centric functional enrichment analysis summarisation tool"
 readme = "README.md"
-requires-python = "==3.7.*"
 classifiers = [
-    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+homepage = "https://avigailtaylor.github.io/GeneFEAST/"
+repository = "https://github.com/avigailtaylor/GeneFEAST"
 
-dependencies = [
-    'matplotlib == 3.3.3',
-    'numpy == 1.17.2',
-    'pandas == 0.25.2',
-    'seaborn == 0.11.2',
-    'upsetplot == 0.4.1',
-    'goatools == 1.0.14',
-    'scipy == 1.3.2',
-    'networkx == 2.5',
-    'lxml == 4.4.1',
-    'beautifulsoup4 == 4.8.0',
-    'pillow == 6.2.0',
-    'PyYAML == 5.1.2'
-]
+[tool.poetry.dependencies]
+python = "^3.12"
+matplotlib = "^3.8.4"
+numpy = "^1.26.4"
+pandas = "^2.2.2"
+seaborn = "^0.13.2"
+upsetplot = "^0.9.0"
+goatools = "^1.4.4"
+scipy = "^1.13.0"
+networkx = "^3.3"
+lxml = "^5.2.1"
+beautifulsoup4 = "^4.12.3"
+pillow = "^10.3.0"
+pyyaml = "^6.0.1"
+setuptools = "^69.5.1"
 
-[tool.setuptools]
-include-package-data = true
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.2.0"
 
-[project.scripts]
+[tool.poetry.scripts]
 gf = "genefeast:gf.main"
 gf_multi = "genefeast:gf_multi.main"
 
-[project.urls]
-"Homepage" = "https://avigailtaylor.github.io/GeneFEAST/"
-"Source Code" = "https://github.com/avigailtaylor/GeneFEAST"


### PR DESCRIPTION
Running GeneFeast with Python 3.12. Used Poetry to resolve all dependencies between packages to run on Python 3.12 from Python 3.7 following discovery of package (h/t Pete Todd).

Successfully ran test python script, only changing how get_renderer() is called (assuming old way of calling has something to do with previous UpsetPlot version though this seems to be something now resolved based on UpsetPlot code).

Ran on recent project data and got the same exact output after small tweak to DataFrame operation (mainly changing .pivot() to .pivot_tables() and associated parameter changes).

On this occasion, addressed most FutureWarnings resulting from Pandas version leap (from 0.25.2 to 2.2.2). Some FutureWarnings from UpsetPlot not directly addressable (though I have made a small pull request on the UpsetPlot repository so may be addressed in the future, just 4 lines).

Question as to whether FutureWarnings from UpsetPlot should be hidden or not in the meantime. Another FutureWarning from Pandas (yes, it's all directly or indirectly Pandas) to be addressed perhaps from input from the Creator (hidden in the meantime?)

Crucially though, it all works.

P.S = Previous UTF8 change I made for Windows is present in this code, otherwise couldn't test on Windows.